### PR TITLE
Change the way ParserOptions are initialized

### DIFF
--- a/includes/WikiTooltips.php
+++ b/includes/WikiTooltips.php
@@ -361,7 +361,7 @@ class WikiTooltips {
     if ( self::$mParser !== null && $titleText !== null && trim( $titleText ) !== '' ) {
       $title = Title::newFromText( $titleText );
       WikiTooltipsCore::flagTooltipAttachmentUnsafe(); // tooltip attaching risks fatal redundant parse here, so disable
-      $parserOptions = ParserOptions::newCanonical( 'canonical' );
+      $parserOptions = new ParserOptions();
       $out = self::$mParser->parse( WikiTooltipsCore::getTooltipWikiText( $title ),
                                     $title,
                                     $parserOptions,
@@ -495,7 +495,7 @@ class WikiTooltips {
                                                                              )
                                                                      ->plain();
           $messageTitle = Title::newFromText( 'MediaWiki:To-tooltip-page-name' );
-          $parserOptions = ParserOptions::newCanonical( 'canonical' );
+          $parserOptions = new ParserOptions();
           $tooltipTitleParse = self::$mParser->parse( $tooltipTitleWikitext,
                                                       $messageTitle,
                                                       $parserOptions,


### PR DESCRIPTION
This actually restores the prev behaviour from [this fix](https://github.com/oOeyes/TippingOver/commit/0f5a88e069102a6acfe2bb7e591113439a0605d3#diff-23c0efbe350e01d8641ec919ba4f4d8fa415c04286ad05891fe1c24205c1801cL334-L338).

`ParserOptions::newCanonnical( 'canonical' )` initialises the options as anon, using default `User` instance & content language. 
`new ParserOptions()` uses `wgUser` and `wgLang`, so there must have be a difference between those (by guess is it's the language) that caused tooltips to not be rendered at all.