### PR TITLE
Follow-up 7a10cd7: Handle LinkTarget in followRedirect()

### DIFF
--- a/includes/WikiTooltipsCore.php
+++ b/includes/WikiTooltipsCore.php
@@ -1,5 +1,6 @@
 <?php
 
+use MediaWiki\Linker\LinkTarget;
 use MediaWiki\MediaWikiServices;
 
 /**
@@ -45,11 +46,16 @@ class WikiTooltipsCore {
   /**
    * This function will check if the given page title references a redirect and returns the redirect target title if
    * it does; otherwise, it returns the title given.
-   * @param Title $title The title to follow any redirect on.
-   * @return Title The original title if it isn't a redirect or the title of the redirect target if it is.
+   * @param LinkTarget|null $title The title to follow any redirect on.
+   * @return LinkTarget|null The original title if it isn't a redirect or the title of the redirect target if it is.
    */
-  public static function followRedirect( $title ) {
-    if ( $title !== null && $title->canExist() ) {
+  public static function followRedirect( ?LinkTarget $title ): ?LinkTarget {
+    if ( $title === null ) {
+	  return null;
+    }
+
+    $title = Title::newFromLinkTarget( $title );
+    if ( $title->canExist() ) {
       $page = MediaWikiServices::getInstance()->getWikiPageFactory()->newFromTitle( $title );
       $target = $page->getRedirectTarget();
       if ( $target !== null ) {


### PR DESCRIPTION
followRedirect() may be called with a LinkTarget implementation
such as TitleValue rather than a full Title, so ensure we cast
it to Title first before attempting to call canExist().

Avoid the following:

```
 Error from line 52 of /extensions/TippingOver/includes/WikiTooltipsCore.php: Call to undefined method TitleValue::canExist()
	#0 /extensions/TippingOver/includes/WikiTooltips.php(495): WikiTooltipsCore::followRedirect(TitleValue)
	#1 /extensions/TippingOver/includes/WikiTooltips.php(614): WikiTooltips::runEarlyTooltipChecks(TitleValue)
	#2 /extensions/TippingOver/includes/WikiTooltips.php(647): WikiTooltips::maybeAttachTooltip(TitleValue, array)
	#3 /includes/HookContainer/HookContainer.php(338): WikiTooltips::linkTooltipRender(MediaWiki\Linker\LinkRenderer, TitleValue, boolean, HtmlArmor, array, NULL)
	#4 /includes/HookContainer/HookContainer.php(137): MediaWiki\HookContainer\HookContainer->callLegacyHook(string, array, array, array)
	#5 /includes/HookContainer/HookRunner.php(2031): MediaWiki\HookContainer\HookContainer->run(string, array)
	#6 /includes/linker/LinkRenderer.php(321): MediaWiki\HookContainer\HookRunner->onHtmlPageLinkRendererEnd(MediaWiki\Linker\LinkRenderer, TitleValue, boolean, HtmlArmor, array, NULL)
	#7 /includes/linker/LinkRenderer.php(217): MediaWiki\Linker\LinkRenderer->buildAElement(TitleValue, HtmlArmor, array, boolean)
	#8 /includes/linker/LinkRenderer.php(248): MediaWiki\Linker\LinkRenderer->makePreloadedLink(TitleValue, HtmlArmor, string, array, array)
	#9 /includes/linker/LinkRenderer.php(165): MediaWiki\Linker\LinkRenderer->makeKnownLink(TitleValue, HtmlArmor, array, array)
	#10 /includes/Linker.php(123): MediaWiki\Linker\LinkRenderer->makeLink(TitleValue, HtmlArmor, array, array)
	#11 /includes/Linker.php(1091): Linker::link(TitleValue, string, array)
	#12 /includes/Linker.php(1335): Linker::userLink(integer, string)
	#13 /includes/actions/pagers/HistoryPager.php(426): Linker::revUserTools(MediaWiki\Revision\RevisionStoreRecord, boolean, boolean)
	#14 /includes/actions/pagers/HistoryPager.php(159): HistoryPager->historyLine(stdClass, stdClass, boolean, boolean, boolean)
	#15 /includes/pager/IndexPager.php(613): HistoryPager->formatRow(stdClass)
	#16 /includes/actions/HistoryAction.php(319): IndexPager->getBody()
	#17 /includes/actions/FormlessAction.php(48): HistoryAction->onView()
	#18 /includes/MediaWiki.php(543): FormlessAction->show()
	#19 /includes/MediaWiki.php(320): MediaWiki->performAction(Article, Title)
	#20 /includes/MediaWiki.php(930): MediaWiki->performRequest()
	#21 /includes/MediaWiki.php(564): MediaWiki->main()
	#22 /index.php(53): MediaWiki->run()
	#23 /index.php(46): wfIndexMain()
	#24 {main}
```