### PR TITLE
Avoid querying the database for non-redirect pages

### DIFF
--- a/includes/WikiTooltipsCore.php
+++ b/includes/WikiTooltipsCore.php
@@ -49,7 +49,9 @@ class WikiTooltipsCore {
    * @return Title|null The original title if it isn't a redirect or the title of the redirect target if it is.
    */
   public static function followRedirect( ?Title $title ): ?Title {
-    if ( $title && $title->canExist() ) {
+	// Optimization: Use isRedirect() so that we only create a full WikiPage for pages known to be redirects.
+    // Loading a WikiPage always triggers a DB query, making it expensive.
+    if ( $title && $title->isRedirect() ) {
       $page = MediaWikiServices::getInstance()->getWikiPageFactory()->newFromTitle( $title );
       $target = $page->getRedirectTarget();
       if ( $target !== null ) {


### PR DESCRIPTION
When parsing large pages, TippingOver may end up triggering thousands of DB queries from followRedirect(), because it creates a full WikiPage on each invocation. Gate this behind an isRedirect() check, which can leverage LinkCache to hopefully avoid a DB query in the common case that the given title is not a redirect.